### PR TITLE
Fix tokenCount memory leak

### DIFF
--- a/src/utils/ContentUtils.ts
+++ b/src/utils/ContentUtils.ts
@@ -33,6 +33,8 @@ export class ContentUtils {
    */
   static tokenCount(prompt: string, model: TiktokenModel = 'gpt-4o'): number {
     const enc = encoding_for_model(model)
-    return enc.encode(prompt).length
+    const tokens = enc.encode(prompt)
+    enc.free()
+    return tokens.length
   }
 }


### PR DESCRIPTION
## Summary
- free tiktoken encoder after counting tokens

## Testing
- `npm run build` *(fails: Cannot find module '@langchain/core/messages')*

------
https://chatgpt.com/codex/tasks/task_e_684303b0b1e88321a912979ad2130a0a