### PR TITLE
Add guide for custom components

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The modktx framework is organized into modular subsystems, each responsible for 
 Reusable content blocks and structured data sources that can be composed into processing pipelines.
 
 👉 [Explore available components](docs/components.md)
+👉 [Create your own component](docs/creating-components.md)
 
 ### Post-Processing Layers
 

--- a/docs/creating-components.md
+++ b/docs/creating-components.md
@@ -1,0 +1,51 @@
+# Creating Custom Components
+
+Custom components allow you to supply dynamic or external data to a
+`ContentComposer`. Any class that implements the `ContentComponent`
+interface can be used as a component. The easiest way is to extend
+`BaseContentComponent` which handles description prompts and basic
+configuration.
+
+## Implementation Steps
+
+1. **Define a configuration interface** describing the parameters your
+   component requires.
+2. **Create default values** so unspecified options fall back to sensible
+   settings.
+3. **Extend `BaseContentComponent`** and call `super()` with a description
+   template and the merged configuration.
+4. **Implement `getContent()`** to return the string that should be added
+   to the final composition. This method may fetch data, perform
+   calculations, or build text.
+
+## Minimal Example
+
+```ts
+import { BaseContentComponent } from 'modktx'
+
+interface MyComponentConfig {
+  description: string
+  endpoint: string
+}
+
+const defaults: MyComponentConfig = {
+  description: 'Data from {{endpoint}}',
+  endpoint: ''
+}
+
+export class MyComponent extends BaseContentComponent<MyComponentConfig> {
+  constructor(config: Partial<MyComponentConfig> = {}) {
+    const merged = { ...defaults, ...config }
+    super(merged.description, merged)
+  }
+
+  async getContent(): Promise<string> {
+    const res = await fetch(this.config.endpoint)
+    return await res.text()
+  }
+}
+```
+
+After defining the class, import it and add an instance to a
+`ContentComposer` just like the built-in components.
+


### PR DESCRIPTION
## Summary
- describe how to implement a custom component
- link the new guide from the README

## Testing
- `npm run ci` *(fails: Cannot find module '@langchain/core/messages' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68430d93e33083219efe8b41376e33bc