### PR TITLE
Add PlaceholderPostProcessor

### DIFF
--- a/docs/postprocessors.md
+++ b/docs/postprocessors.md
@@ -11,21 +11,21 @@ This component is suitable for exporting trading data in a tabular format for vi
 ### Input Format
 
 - The input must be a **JSON string** with a single top-level key (e.g., `"5m"`), mapping to an object containing:
-    - `candles`: An array of OHLCV candle objects
-    - `indicators`: An array of indicator objects aligned by time with the candles
+  - `candles`: An array of OHLCV candle objects
+  - `indicators`: An array of indicator objects aligned by time with the candles
 
 ### Output Format
 
 - A **CSV string** with the following characteristics:
-    - Always includes OHLCV columns: `time, open, high, low, close, volume`
-    - Includes only the technical indicator columns present in the input:
-        - `sma`
-        - `ema`
-        - `rsi`
-        - `macd, signal, hist`
-        - `atr`
-        - `bbLower, bbMiddle, bbUpper`
-    - Rows are aligned by `time`, and missing values are represented as empty fields.
+  - Always includes OHLCV columns: `time, open, high, low, close, volume`
+  - Includes only the technical indicator columns present in the input:
+    - `sma`
+    - `ema`
+    - `rsi`
+    - `macd, signal, hist`
+    - `atr`
+    - `bbLower, bbMiddle, bbUpper`
+  - Rows are aligned by `time`, and missing values are represented as empty fields.
 
 ### Supported Indicators per Row
 
@@ -46,19 +46,19 @@ If present, the following indicators are added to each row (after OHLCV):
 
 ```ts
 new ContentPostProcessor(
-    new OHLCVComponent({
-      exchange: 'binance',
-      symbol: 'BTC/USDT',
-      timeframe: '1d',
-      inputCandles: 60,
-      outputCandles: 10,
-      indicators: {
-        sma: {period: 20},
-        rsi: {period: 14},
-        bbands: {period: 20, stddev: 2}
-      },
-    }),
-    new OHLCVCSVFormatter()
+  new OHLCVComponent({
+    exchange: 'binance',
+    symbol: 'BTC/USDT',
+    timeframe: '1d',
+    inputCandles: 60,
+    outputCandles: 10,
+    indicators: {
+      sma: { period: 20 },
+      rsi: { period: 14 },
+      bbands: { period: 20, stddev: 2 },
+    },
+  }),
+  new OHLCVCSVFormatter(),
 )
 ```
 
@@ -75,6 +75,7 @@ time,open,high,low,close,volume,sma,rsi,bbLower,bbMiddle,bbUpper
 ### Purpose
 
 `JsonProjectionFilter` is a JSON filter that post-processes structured JSON content by:
+
 - Preserving the overall structure of the input JSON,
 - Traversing deeply nested objects and arrays,
 - Retaining only the keys specified in a given `projection` schema,
@@ -86,10 +87,10 @@ It is especially suitable for narrowing down large and deeply nested JSON datase
 
 This post-processor is constructed via its class constructor rather than a configuration object, but it accepts the following parameters:
 
-| Parameter    | Type        | Required | Default     | Description                                                                 |
-|--------------|-------------|----------|-------------|-----------------------------------------------------------------------------|
-| `projection` | `Projection`| Yes      | –           | An object that specifies which keys to keep. Keys can map to `true` or nested projection objects. |
-| `limit`      | `number`    | No       | `undefined` | If set, limits the number of entries in all arrays (keeps the last `N` items). |
+| Parameter    | Type         | Required | Default     | Description                                                                                       |
+| ------------ | ------------ | -------- | ----------- | ------------------------------------------------------------------------------------------------- |
+| `projection` | `Projection` | Yes      | –           | An object that specifies which keys to keep. Keys can map to `true` or nested projection objects. |
+| `limit`      | `number`     | No       | `undefined` | If set, limits the number of entries in all arrays (keeps the last `N` items).                    |
 
 #### Projection Type
 
@@ -100,6 +101,7 @@ type Projection = {
 ```
 
 Each key in the projection object may be:
+
 - `true`: include the entire matching field value,
 - another projection: recursively apply projection rules to a nested object.
 
@@ -122,8 +124,8 @@ new ContentPostProcessor(
   new JsonProjectionFilter({
     time: true,
     close: true,
-    rsi: true
-  })
+    rsi: true,
+  }),
 )
 ```
 
@@ -168,10 +170,10 @@ This processor is particularly suitable for use cases such as rephrasing, summar
 
 This post-processor is initialized with:
 
-| Parameter   | Type         | Required | Description                                                  |
-|-------------|--------------|----------|--------------------------------------------------------------|
-| `prompt`    | `string`     | Yes      | A prompt string that guides the AI's behavior.               |
-| `provider`  | `ChatProvider` | Yes    | The chat provider instance used to communicate with the AI.  |
+| Parameter  | Type           | Required | Description                                                 |
+| ---------- | -------------- | -------- | ----------------------------------------------------------- |
+| `prompt`   | `string`       | Yes      | A prompt string that guides the AI's behavior.              |
+| `provider` | `ChatProvider` | Yes      | The chat provider instance used to communicate with the AI. |
 
 ### Behavior
 
@@ -184,10 +186,37 @@ This post-processor is initialized with:
 
 ```ts
 new ContentPostProcessor(
-  new TextComponent("Please write a professional summary of the following content..."),
+  new TextComponent(
+    'Please write a professional summary of the following content...',
+  ),
   new ChatPostProcessor(
-    "You are a helpful assistant that rewrites content in a formal and concise manner.",
-    new OpenAIChatProvider({ model: "gpt-4o" })
-  )
+    'You are a helpful assistant that rewrites content in a formal and concise manner.',
+    new OpenAIChatProvider({ model: 'gpt-4o' }),
+  ),
 )
 ```
+
+## PlaceholderPostProcessor
+
+### Purpose
+
+`PlaceholderPostProcessor` replaces placeholders in the format `{{key}}` with the matching value from a provided map.
+
+### Configuration
+
+This processor is constructed with:
+
+| Parameter      | Type                     | Required | Description                         |
+| -------------- | ------------------------ | -------- | ----------------------------------- |
+| `placeholders` | `Record<string, string>` | Yes      | Map of placeholder names to values. |
+
+### Example
+
+```ts
+new ContentPostProcessor(
+  new TextComponent('Hello {{name}}!'),
+  new PlaceholderPostProcessor({ name: 'Alice' }),
+)
+```
+
+**Output:** `Hello Alice!`

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from './decorators/ContentPostProcessor.js'
 export * from './postprocessors/JsonProjectionFilter.js'
 export * from './postprocessors/OHLCVCSVFormatter.js'
 export * from './postprocessors/ChatPostProcessor.js'
+export * from './postprocessors/PlaceholderPostProcessor.js'
 
 export * from './jobs/JobScheduler.js'
 export * from './jobs/Task.js'

--- a/src/postprocessors/PlaceholderPostProcessor.ts
+++ b/src/postprocessors/PlaceholderPostProcessor.ts
@@ -1,0 +1,23 @@
+import type { PostProcessor } from './PostProcessor.js'
+
+/**
+ * PlaceholderPostProcessor replaces placeholders in the form `{{key}}`
+ * with their corresponding values from a provided map.
+ */
+export class PlaceholderPostProcessor implements PostProcessor {
+  private readonly placeholders: Record<string, string>
+
+  constructor(placeholders: Record<string, string>) {
+    this.placeholders = placeholders
+  }
+
+  async postProcess(content: string): Promise<string> {
+    let result = content
+    for (const [key, value] of Object.entries(this.placeholders)) {
+      const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      const regex = new RegExp(`{{${escapedKey}}}`, 'g')
+      result = result.replace(regex, value)
+    }
+    return result
+  }
+}


### PR DESCRIPTION
## Summary
- add `PlaceholderPostProcessor` to replace `{{key}}` placeholders
- export the new postprocessor
- document `PlaceholderPostProcessor` in postprocessor docs

## Testing
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68431a2c2518832182b52256b1f562bd