### PR TITLE
Refactor chat providers

### DIFF
--- a/src/chat/ChatBaseProvider.ts
+++ b/src/chat/ChatBaseProvider.ts
@@ -1,0 +1,64 @@
+import type { MessageContent } from '@langchain/core/messages'
+import { ZodObject } from 'zod'
+import type { ChatProvider } from './ChatProvider.js'
+
+/**
+ * ChatBaseProvider implements common ChatProvider functionality such as
+ * simple invocation, streaming and Zod based validation for structured output.
+ * Specific providers only need to implement creation of the underlying chat
+ * model and the provider specific structured output and websearch logic.
+ */
+export abstract class ChatBaseProvider implements ChatProvider {
+  protected abstract chat: any
+
+  /**
+   * Invokes the underlying chat model with the given prompt.
+   */
+  async invoke(prompt: string): Promise<MessageContent> {
+    const result = await this.chat.invoke(prompt)
+    return result.content
+  }
+
+  /**
+   * Internal hook returning the raw structured result from the provider
+   * without any validation applied.
+   */
+  protected abstract invokeStructuredRaw(
+    prompt: string,
+    zodObject: ZodObject<any>,
+  ): Promise<any>
+
+  /**
+   * Invokes the provider expecting structured output. The result will be
+   * validated using the provided Zod schema.
+   */
+  async invokeWithStructuredOutput(
+    prompt: string,
+    zodObject: ZodObject<any>,
+  ): Promise<{ [p: string]: any }> {
+    const raw = await this.invokeStructuredRaw(prompt, zodObject)
+    const validated = zodObject.safeParse(raw)
+    if (!validated.success) {
+      throw new Error(`Zod validation failed: ${validated.error.format()}`)
+    }
+    return validated.data
+  }
+
+  /**
+   * Streams the LLM response as an async iterable.
+   */
+  async *stream(prompt: string): AsyncIterable<{ content: string }> {
+    const stream = await this.chat.stream(prompt)
+    for await (const chunk of stream) {
+      yield { content: `${chunk.content}` }
+    }
+  }
+
+  /**
+   * Optional websearch support. Providers should override this method to
+   * implement their tooling configuration.
+   */
+  async websearch(prompt: string, _config?: any): Promise<MessageContent> {
+    throw new Error('Websearch is not supported by this provider')
+  }
+}

--- a/src/chat/ChatClient.ts
+++ b/src/chat/ChatClient.ts
@@ -1,6 +1,5 @@
 import type { MessageContent } from '@langchain/core/messages'
 import type { ChatProvider } from './ChatProvider.js'
-import { ZodObject } from 'zod'
 
 /**
  * ChatClient is a wrapper around a ChatProvider that provides methods to invoke LLM prompts.
@@ -43,17 +42,9 @@ export class ChatClient {
    */
   async invokeWithStructuredOutput(
     prompt: string,
-    zodObject: ZodObject<any>,
+    zodObject: any,
   ): Promise<{ [p: string]: any }> {
-    const result = await this.provider.invokeWithStructuredOutput(
-      prompt,
-      zodObject,
-    )
-    const validated = zodObject.safeParse(result)
-    if (!validated.success) {
-      throw new Error(`Zod validation failed: ${validated.error.format()}`)
-    }
-    return validated.data
+    return await this.provider.invokeWithStructuredOutput(prompt, zodObject)
   }
 
   /**
@@ -76,7 +67,7 @@ export class ChatClient {
    * TODO
    * @param prompt
    */
-  async websearch(prompt: string): Promise<MessageContent> {
-    return await this.provider.websearch(prompt)
+  async websearch(prompt: string, config?: any): Promise<MessageContent> {
+    return await this.provider.websearch(prompt, config)
   }
 }

--- a/src/chat/ChatProvider.ts
+++ b/src/chat/ChatProvider.ts
@@ -32,5 +32,5 @@ export interface ChatProvider {
    * TODO
    * @param prompt
    */
-  websearch(prompt: string): Promise<MessageContent>
+  websearch(prompt: string, config?: any): Promise<MessageContent>
 }

--- a/src/chat/OllamaProvider.ts
+++ b/src/chat/OllamaProvider.ts
@@ -1,9 +1,9 @@
 import type { MessageContent } from '@langchain/core/messages'
 import { ChatOllama, type ChatOllamaInput } from '@langchain/ollama'
 import { zodToJsonSchema } from 'zod-to-json-schema'
-import type { ChatProvider } from './ChatProvider.js'
-import logger from '../logger.js'
 import { ZodObject } from 'zod'
+import { ChatBaseProvider } from './ChatBaseProvider.js'
+import logger from '../logger.js'
 
 const defaultConfig: ChatOllamaInput = {
   model: 'qwen2.5:latest',
@@ -14,28 +14,19 @@ const defaultConfig: ChatOllamaInput = {
  * OllamaProvider implements the ChatProvider interface using the Ollama LLM backend.
  * It supports plain-text invocation, structured output via Zod schemas, and streaming responses.
  */
-export class OllamaProvider implements ChatProvider {
+export class OllamaProvider extends ChatBaseProvider {
   private config: ChatOllamaInput
-  private chat: ChatOllama
+  protected chat: ChatOllama
 
   /**
    * Constructs a new OllamaProvider with optional configuration overrides.
    * @param config - Partial configuration for the ChatOllama instance (e.g., model name, context length).
    */
   constructor(config: Partial<ChatOllamaInput> = {}) {
+    super()
     this.config = { ...defaultConfig, ...config }
     logger.debug(`OllamaProvider config=${JSON.stringify(this.config)}`)
     this.chat = new ChatOllama(this.config)
-  }
-
-  /**
-   * Sends a plain-text prompt to the Ollama chat model and returns the raw message content.
-   * @param prompt - The text prompt to send to the LLM.
-   * @returns A Promise resolving to the MessageContent returned by the model.
-   */
-  async invoke(prompt: string): Promise<MessageContent> {
-    const response = await this.chat.invoke(prompt)
-    return response.content
   }
 
   /**
@@ -46,10 +37,10 @@ export class OllamaProvider implements ChatProvider {
    * @returns A Promise resolving to the parsed object matching the schema.
    * @throws Error if JSON parsing fails.
    */
-  async invokeWithStructuredOutput(
+  protected override async invokeStructuredRaw(
     prompt: string,
     zodObject: ZodObject<any>,
-  ): Promise<{ [p: string]: any }> {
+  ): Promise<any> {
     this.chat.format = zodToJsonSchema(zodObject)
     let result = await this.chat.invoke(prompt)
 
@@ -66,22 +57,10 @@ export class OllamaProvider implements ChatProvider {
   }
 
   /**
-   * Streams the response from Ollama token-by-token as an async iterable.
-   * @param prompt - The text prompt to send to the LLM.
-   * @yields Chunks of the response as objects with a `content` string property.
-   */
-  async *stream(prompt: string): AsyncIterable<{ content: string }> {
-    const stream = await this.chat.stream(prompt)
-    for await (const chunk of stream) {
-      yield { content: `${chunk.content}` }
-    }
-  }
-
-  /**
    * TODO
    * @param prompt
    */
-  async websearch(prompt: string): Promise<MessageContent> {
+  override async websearch(prompt: string): Promise<MessageContent> {
     throw new Error(`Not supported yet!`)
   }
 }

--- a/src/chat/OpenAIProvider.ts
+++ b/src/chat/OpenAIProvider.ts
@@ -1,7 +1,7 @@
 import type { MessageContent } from '@langchain/core/messages'
 import { ChatOpenAI, type ChatOpenAIFields } from '@langchain/openai'
-import type { ChatProvider } from './ChatProvider.js'
 import { ZodObject } from 'zod'
+import { ChatBaseProvider } from './ChatBaseProvider.js'
 import logger from '../logger.js'
 
 const defaultConfig: ChatOpenAIFields = {
@@ -12,54 +12,31 @@ const defaultConfig: ChatOpenAIFields = {
  * OpenAIProvider implements the ChatProvider interface using the OpenAI backend.
  * It supports plain-text invocation, structured output via Zod schemas, and streaming responses.
  */
-export class OpenAIProvider implements ChatProvider {
+export class OpenAIProvider extends ChatBaseProvider {
   private config: ChatOpenAIFields
-  private chat: ChatOpenAI
+  protected chat: ChatOpenAI
+  private websearchDefaults: any = { search_context_size: 'medium' }
 
   /**
    * Constructs a new OpenAIProvider with optional configuration overrides.
    * @param config - Partial configuration for the ChatOpenAI instance (e.g., model name).
    */
-  constructor(config: Partial<ChatOpenAIFields> = {}) {
-    this.config = { ...defaultConfig, ...config }
+  constructor(config: Partial<ChatOpenAIFields & { websearch?: any }> = {}) {
+    super()
+    const { websearch, ...chatConfig } = config
+    this.config = { ...defaultConfig, ...chatConfig }
+    if (websearch)
+      this.websearchDefaults = { ...this.websearchDefaults, ...websearch }
     logger.debug(`OpenAIProvider config=${JSON.stringify(this.config)}`)
     this.chat = new ChatOpenAI(this.config)
   }
 
-  /**
-   * Sends a plain-text prompt to the OpenAI chat model and returns the raw message content.
-   * @param prompt - The text prompt to send to the LLM.
-   * @returns A Promise resolving to the MessageContent returned by the model.
-   */
-  async invoke(prompt: string): Promise<MessageContent> {
-    const response = await this.chat.invoke(prompt)
-    return response.content
-  }
-
-  /**
-   * Sends a prompt to OpenAI with a Zod schema to enforce structured JSON output.
-   * @param prompt - The text prompt to send to the LLM.
-   * @param zodObject - A ZodObject describing the expected structure of the JSON output.
-   * @returns A Promise resolving to the parsed object matching the schema.
-   */
-  async invokeWithStructuredOutput(
+  protected override async invokeStructuredRaw(
     prompt: string,
     zodObject: ZodObject<any>,
-  ): Promise<{ [p: string]: any }> {
+  ): Promise<any> {
     const structuredLlm = this.chat.withStructuredOutput(zodObject)
     return await structuredLlm.invoke(prompt)
-  }
-
-  /**
-   * Streams the response from OpenAI token-by-token as an async iterable.
-   * @param prompt - The text prompt to send to the LLM.
-   * @yields Chunks of the response as objects with a `content` string property.
-   */
-  async *stream(prompt: string): AsyncIterable<{ content: string }> {
-    const stream = await this.chat.stream(prompt)
-    for await (const chunk of stream) {
-      yield { content: `${chunk.content}` }
-    }
   }
 
   /**
@@ -67,18 +44,24 @@ export class OpenAIProvider implements ChatProvider {
    * https://platform.openai.com/docs/guides/tools-web-search
    * @param prompt
    */
-  async websearch(prompt: string): Promise<MessageContent> {
-    const llmWithTools = this.chat.bindTools([
-      { type: 'web_search_preview', search_context_size: 'medium' },
-    ])
+  override async websearch(
+    prompt: string,
+    config: any = {},
+  ): Promise<MessageContent> {
+    const tool = {
+      type: 'web_search_preview',
+      ...this.websearchDefaults,
+      ...config,
+    }
+    const llmWithTools = this.chat.bindTools([tool])
     const response = await llmWithTools.invoke(prompt)
-    const content = response.content;
+    const content = response.content
     if (Array.isArray(content)) {
       // we assume that each element is a { text: string }
       return content
         .map((block: any) => block.text ?? '')
         .filter((txt: string) => txt.length > 0)
-        .join('\n\n');
+        .join('\n\n')
     } else {
       // content is already a string
       return content

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './chat/ChatClient.js'
+export * from './chat/ChatBaseProvider.js'
 export * from './chat/OllamaProvider.js'
 export * from './chat/OpenAIProvider.js'
 export * from './chat/GoogleAIProvider.js'


### PR DESCRIPTION
## Summary
- unify chat provider logic with new `ChatBaseProvider`
- move structured output validation into base class
- allow providers to override websearch configuration
- support optional websearch options in `ChatClient`
- document new usage and configuration

## Testing
- `npm run build`
- `npm run check-format`
- `npm run check-exports`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68456fcc12d88321a8e28c0dee88a2ab