### PR TITLE
Fix OHLCVCSVFormatter with filtered input

### DIFF
--- a/docs/postprocessors.md
+++ b/docs/postprocessors.md
@@ -19,7 +19,7 @@ This component is suitable for exporting trading data in a tabular format for vi
 ### Output Format
 
 - A **CSV string** with the following characteristics:
-  - Always includes OHLCV columns: `time, open, high, low, close, volume`
+  - Includes OHLCV columns only for fields present in the input (e.g., `time`, `open`, `high`, `low`, `close`, `volume`)
   - Includes only those technical indicator columns that are present in the input:
     - `sma`
     - `ema`


### PR DESCRIPTION
## Summary
- handle optional candle fields in `OHLCVCSVFormatter`
- detect missing indicator timestamps and align by index
- generate headers only for available OHLCV fields
- document updated behaviour

## Testing
- `npm run build`
- `npm run check-format`
- `npm run check-exports`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6849502fca608321876065f6168bfe11